### PR TITLE
Exclude images from context?

### DIFF
--- a/llms_txt/core.py
+++ b/llms_txt/core.py
@@ -70,7 +70,8 @@ def _doc(kw):
     "Create a `Doc` FT object with the text retrieved from `url` as the child, and `kw` as attrs."
     url = kw.pop('url')
     re_comment = re.compile('^<!--.*-->$', flags=re.MULTILINE)
-    txt = [o for o in httpx.get(url).text.splitlines() if not re_comment.search(o)]
+    re_base64_img = re.compile(r'<img[^>]*src="data:image/[^"]*"[^>]*>')
+    txt = [o for o in httpx.get(url).text.splitlines() if not re_comment.search(o) and not re_base64_img.search(o)]
     return Doc('\n'.join(txt), **kw)
 
 # %% ../nbs/01_core.ipynb

--- a/nbs/01_core.ipynb
+++ b/nbs/01_core.ipynb
@@ -684,7 +684,8 @@
     "    \"Create a `Doc` FT object with the text retrieved from `url` as the child, and `kw` as attrs.\"\n",
     "    url = kw.pop('url')\n",
     "    re_comment = re.compile('^<!--.*-->$', flags=re.MULTILINE)\n",
-    "    txt = [o for o in httpx.get(url).text.splitlines() if not re_comment.search(o)]\n",
+    "    re_base64_img = re.compile(r'<img[^>]*src=\"data:image/[^\"]*\"[^>]*>')\n",
+    "    txt = [o for o in httpx.get(url).text.splitlines() if not re_comment.search(o) and not re_base64_img.search(o)]\n",
     "    return Doc('\\n'.join(txt), **kw)"
    ]
   },


### PR DESCRIPTION
I found that when we have images in our docs the base64 text is often being included in the context (ex: when I was working on https://github.com/fastai/fastcore/pull/621).  I think this might be taking up too many tokens, and maybe good to exclude them?