### PR TITLE
docs: add vite-plugin-llms to integrations section

### DIFF
--- a/nbs/index.qmd
+++ b/nbs/index.qmd
@@ -115,6 +115,14 @@ Here are a few directories that list the `llms.txt` files available on the web:
 - [llmstxt.site](https://llmstxt.site/)
 - [directory.llmstxt.cloud](https://directory.llmstxt.cloud/)
 
+## Integrations
+
+Various tools and plugins are available to help integrate the llms.txt specification into your workflow:
+
+- [`llms_txt2ctx`](https://llmstxt.org/intro.html#cli) - CLI and Python module for parsing llms.txt files and generating LLM context
+- [JavaScript Implementation](./llmstxt-js.html) - Sample JavaScript implementation
+- [vite-plugin-llms](https://github.com/yourusername/vite-plugin-llms) - Vite plugin that serves markdown files alongside your routes following the llms.txt specification
+
 ## Next steps
 
 The `llms.txt` specification is open for community input. A [GitHub repository](https://github.com/AnswerDotAI/llms-txt) hosts [this informal overview](https://github.com/AnswerDotAI/llms-txt/blob/main/nbs/index.md), allowing for version control and public discussion. A [community discord channel](https://discord.gg/aJPygMvPEN) is available for sharing implementation experiences and discussing best practices.


### PR DESCRIPTION
### Overview

This PR adds `vite-plugin-llms` to the integrations section, providing an easy way for Vite-based projects to implement the llms.txt specification.

### Why this integration matters

The plugin solves several key challenges for web applications:
- Automatically serves markdown files alongside routes with `.md` extension
- Handles the `/llms.txt` file in development and production
- Works with any Vite-based framework (Vue, React, Svelte, etc.)
- Zero configuration needed to follow the specification

### Change

```markdown
## Integrations

Various tools and plugins are available to help integrate the llms.txt specification into your workflow:

- [`llms_txt2ctx`](https://llmstxt.org/intro.html#cli) - CLI and Python module for parsing llms.txt files and generating LLM context
- [JavaScript Implementation](./llmstxt-js.html) - Sample JavaScript implementation
- [vite-plugin-llms](https://github.com/yourusername/vite-plugin-llms) - Vite plugin that serves markdown files alongside your routes following the llms.txt specification