### PR TITLE
Fix Bug when notebooks are at the root

### DIFF
--- a/llms_txt/core.py
+++ b/llms_txt/core.py
@@ -69,7 +69,10 @@ from fastcore.xml import Sections,Project,Doc
 
 # %% ../nbs/01_core.ipynb
 def _local_docs_pth(cfg): return cfg.config_path/'_proc'/cfg.doc_path
-def _get_config(): return Config.find('settings.ini')
+def _get_config(): 
+    cwd = os.getcwd() 
+    # when notebooks are in the root, the build cache preserves the settings.ini in `_proc`
+    return Config.find('settings.ini', Path(cwd).parent if cwd.endswith('_proc') else None) 
 
 def get_doc_content(url):
     "Fetch content from local file if in nbdev repo."

--- a/llms_txt/core.py
+++ b/llms_txt/core.py
@@ -71,7 +71,7 @@ from fastcore.xml import Sections,Project,Doc
 def _local_docs_pth(cfg): return cfg.config_path/'_proc'/cfg.doc_path
 def _get_config(): 
     cwd = os.getcwd() 
-    # when notebooks are in the root, the build cache preserves the settings.ini in `_proc`
+    # when notebooks are in the root, the nbdev preserves the settings.ini in `_proc`
     return Config.find('settings.ini', Path(cwd).parent if cwd.endswith('_proc') else None) 
 
 def get_doc_content(url):

--- a/nbs/01_core.ipynb
+++ b/nbs/01_core.ipynb
@@ -683,7 +683,7 @@
     "def _local_docs_pth(cfg): return cfg.config_path/'_proc'/cfg.doc_path\n",
     "def _get_config(): \n",
     "    cwd = os.getcwd() \n",
-    "    # when notebooks are in the root, the build cache preserves the settings.ini in `_proc`\n",
+    "    # when notebooks are in the root, the nbdev preserves the settings.ini in `_proc`\n",
     "    return Config.find('settings.ini', Path(cwd).parent if cwd.endswith('_proc') else None) \n",
     "\n",
     "def get_doc_content(url):\n",

--- a/nbs/01_core.ipynb
+++ b/nbs/01_core.ipynb
@@ -681,7 +681,10 @@
    "source": [
     "#|export\n",
     "def _local_docs_pth(cfg): return cfg.config_path/'_proc'/cfg.doc_path\n",
-    "def _get_config(): return Config.find('settings.ini')\n",
+    "def _get_config(): \n",
+    "    cwd = os.getcwd() \n",
+    "    # when notebooks are in the root, the build cache preserves the settings.ini in `_proc`\n",
+    "    return Config.find('settings.ini', Path(cwd).parent if cwd.endswith('_proc') else None) \n",
     "\n",
     "def get_doc_content(url):\n",
     "    \"Fetch content from local file if in nbdev repo.\"\n",


### PR DESCRIPTION
cc @jph00 

I tested this on fastcore and ghapi and it works.  
I didn't want to change `Config.find` in fastcore as that is doing the right thing if outside nbdev.  

This is just an edge case where when notebooks are in the root the `settings.ini` is present in `_proc`.  