### PR TITLE
docs: add `vitepress-plugin-llms` to the Integrations section

### DIFF
--- a/nbs/index.qmd
+++ b/nbs/index.qmd
@@ -124,7 +124,7 @@ Various tools and plugins are available to help integrate the llms.txt specifica
 
 - [`llms_txt2ctx`](https://llmstxt.org/intro.html#cli) - CLI and Python module for parsing llms.txt files and generating LLM context
 - [JavaScript Implementation](./llmstxt-js.html) - Sample JavaScript implementation
-- [vite-plugin-llms](https://github.com/saschaseniuk/vite-plugin-llms) - Vite plugin that serves markdown files alongside your routes following the llms.txt specification
+- [`vitepress-plugin-llms`](https://github.com/okineadev/vitepress-plugin-llms) - VitePress plugin that automatically generates LLM-friendly documentation for the website following the llms.txt specification
 
 ## Next steps
 


### PR DESCRIPTION
I don't know if it's appropriate to delete the previous plugin, it's just that the idea in that plugin is completely different, mine generates documentation for LLMs in the VitePress output folder and not in the project itself

Plugin repository: https://github.com/okineadev/vitepress-plugin-llms