### PR TITLE
Add link to sphinx-llm

### DIFF
--- a/nbs/index.qmd
+++ b/nbs/index.qmd
@@ -129,6 +129,7 @@ Various tools and plugins are available to help integrate the llms.txt specifica
 - [`docusaurus-plugin-llms`](https://github.com/rachfop/docusaurus-plugin-llms) - Docusaurus plugin for generating LLM-friendly documentation following the llmtxt.org standard
 - [Drupal LLM Support](https://www.drupal.org/project/llm_support) - A Drupal Recipe providing full support for the llms.txt proposal on any Drupal 10.3+ site
 - [`llms-txt-php`](https://github.com/raphaelstolt/llms-txt-php) - A library for writing and reading llms.txt Markdown files
+- [`sphinx-llm`](https://pypi.org/project/sphinx-llm/) - A Sphinx plugin that provides llms.txt support in Sphinx documentation.
 
 ## Next steps
 


### PR DESCRIPTION
I just published `sphinx-llm` which has LLM related extensions for Sphinx. I just added an extension that generates llms.txt compatible files when building Sphinx docs.