### PR TITLE
Add llms.txt generator Chrome Extension

### DIFF
--- a/nbs/index.qmd
+++ b/nbs/index.qmd
@@ -129,6 +129,7 @@ Various tools and plugins are available to help integrate the llms.txt specifica
 - [`docusaurus-plugin-llms`](https://github.com/rachfop/docusaurus-plugin-llms) - Docusaurus plugin for generating LLM-friendly documentation following the llmtxt.org standard
 - [Drupal LLM Support](https://www.drupal.org/project/llm_support) - A Drupal Recipe providing full support for the llms.txt proposal on any Drupal 10.3+ site
 - [`llms-txt-php`](https://github.com/raphaelstolt/llms-txt-php) - A library for writing and reading llms.txt Markdown files
+- [`llms.txt Generator Chrome Extension`](https://chromewebstore.google.com/detail/llmstxt-generator/hkfhiobimmpeimihkebmpmppjlkofjie) - Google Chrome extension that generates llms.txt files for each page available in sitemap.xml and current open page
 
 ## Next steps
 


### PR DESCRIPTION
Open-source: https://github.com/plainsignal/llmstxt
Chrome extension link: https://chromewebstore.google.com/detail/llmstxt-generator/hkfhiobimmpeimihkebmpmppjlkofjie
Reason: Help website owners quickly generate llms.txt files for their content without leaving their browser. Useful mostly for the people does not want to deal with command line tools.