### PR TITLE
Add VS Code PagePilot Extension to documentation

### DIFF
--- a/nbs/index.qmd
+++ b/nbs/index.qmd
@@ -129,6 +129,7 @@ Various tools and plugins are available to help integrate the llms.txt specifica
 - [`docusaurus-plugin-llms`](https://github.com/rachfop/docusaurus-plugin-llms) - Docusaurus plugin for generating LLM-friendly documentation following the llmtxt.org standard
 - [Drupal LLM Support](https://www.drupal.org/project/llm_support) - A Drupal Recipe providing full support for the llms.txt proposal on any Drupal 10.3+ site
 - [`llms-txt-php`](https://github.com/raphaelstolt/llms-txt-php) - A library for writing and reading llms.txt Markdown files
+- [`VS Code PagePilot Extension`](https://dmux.github.io/pagepilot) - PagePilot is a VS Code Chat participant that automatically loads external context (documentation, APIs, README files) to provide enhanced responses.
 
 ## Next steps
 


### PR DESCRIPTION
This pull request adds a new tool to the list of integrations supporting the llms.txt specification. Specifically, it introduces the VS Code PagePilot Extension, which enhances VS Code chat by automatically loading external context for improved responses.

Tool integrations:

* Added the `VS Code PagePilot Extension` to the list of tools, describing its ability to load external documentation and APIs for enhanced chat responses in VS Code.