### PR TITLE
Add Pressonify.ai to Implementations section

### DIFF
--- a/nbs/index.qmd
+++ b/nbs/index.qmd
@@ -119,6 +119,12 @@ Here are a few directories that list the `llms.txt` files available on the web:
 - [llmstxt.site](https://llmstxt.site/)
 - [directory.llmstxt.cloud](https://directory.llmstxt.cloud/)
 
+## Implementations
+
+Notable production sites implementing the `llms.txt` specification:
+
+- [Pressonify.ai](https://pressonify.ai/llms.txt) - AI-powered press release platform with a 3-tier llms.txt strategy ([`llms.txt`](https://pressonify.ai/llms.txt), [`llms-full.txt`](https://pressonify.ai/llms-full.txt), [`llms-lite.txt`](https://pressonify.ai/llms-lite.txt)), plus section-specific feeds at [`/news/llms.txt`](https://pressonify.ai/news/llms.txt) and [`/wiki/llms.txt`](https://pressonify.ai/wiki/llms.txt), a [knowledge graph](https://pressonify.ai/knowledge-graph.json), and an MCP server with OAuth 2.0 for agent discovery.
+
 ## Integrations
 
 Various tools and plugins are available to help integrate the llms.txt specification into your workflow:


### PR DESCRIPTION
Adds a new "Implementations" subsection under Directories, listing Pressonify.ai as a notable production site implementing the llms.txt specification.

## About Pressonify

Pressonify is an AI-powered press release platform that implements a comprehensive llms.txt strategy:

- **3-tier llms.txt**: [`/llms.txt`](https://pressonify.ai/llms.txt) (~34KB), [`/llms-full.txt`](https://pressonify.ai/llms-full.txt) (~54KB), [`/llms-lite.txt`](https://pressonify.ai/llms-lite.txt) (~1KB)
- **Section-specific feeds**: [`/news/llms.txt`](https://pressonify.ai/news/llms.txt) for press releases, [`/wiki/llms.txt`](https://pressonify.ai/wiki/llms.txt) for knowledge graph entities
- **Knowledge graph**: [`/knowledge-graph.json`](https://pressonify.ai/knowledge-graph.json) with 75+ entities
- **MCP server** with OAuth 2.0 for agent discovery
- 36+ ADP endpoints for AI discoverability

## Rationale

The spec repo already hosts a "Directories" section pointing at external directories of llms.txt sites, but there is no in-repo list of notable implementations. This PR introduces a lightweight "Implementations" subsection so readers landing on the spec can see a real-world production example without leaving the page. Happy to reshape or relocate the entry (e.g., move under an existing section, or drop it entirely) if maintainers prefer to keep site listings solely in the external directories.