### PR TITLE
Fix typo: `Franklin's BBQ` -> `Franklin BBQ`

### DIFF
--- a/nbs/domains.md
+++ b/nbs/domains.md
@@ -59,7 +59,7 @@ Here are our weekly hours:
 - [Dessert Menu](https://host/dessert.md): A subset of the Starlette docs
 ```
 
-And here is an example lunch menu taken from [Franklin's BBQ](https://franklinbbq.com/menu):
+And here is an example lunch menu taken from [Franklin BBQ](https://franklinbbq.com/menu):
 
 ```
 ## By The Pound


### PR DESCRIPTION
See attached image

https://franklinbbq.com/menu

<img width="1071" height="658" alt="Screenshot 2026-05-06 at 11 22 10 AM" src="https://github.com/user-attachments/assets/aa790e05-07d0-4d7a-8d4d-140a9a788d24" />
