### PR TITLE
Add agents.txt v1.0 (lineage cross-link)

### DIFF
--- a/agents.txt
+++ b/agents.txt
@@ -1,0 +1,57 @@
+# agents.txt - guidance for AI agents interacting with this repository
+# Spec: https://github.com/barneywohl/agentpress (agents.txt v1.0)
+
+[meta]
+spec_version = 1.0
+project = llms-txt
+maintainer = github@jhoward.fastmail.fm
+contact_for_agents = github@jhoward.fastmail.fm
+last_updated = 2026-05-13
+license = Apache-2.0
+ai_disclosure_required = true
+
+[allowed_actions]
+read_documentation
+read_source_code
+run_tests_in_ci
+file_pull_request
+comment_on_issue
+propose_spec_clarification
+suggest_example
+
+[prohibited_actions]
+merge_to_main
+publish_to_pypi
+modify_secrets
+force_push
+rewrite_history
+impersonate_maintainer
+mass_open_issues
+spam
+
+[requires_human_approval]
+changes_to_spec_text
+changes_touching = nbs/**, llms_txt/**, pyproject.toml
+new_dependencies
+release_tagging
+
+[entry_points]
+agent_guide = agents.txt
+contributing = README.md
+architecture = nbs/index.qmd
+test_command = nbtest
+
+[disclosure]
+pr_label = agent-authored
+commit_trailer = Co-Authored-By
+require_attribution_in_pr_body = true
+
+[scope]
+max_files_per_pr = 10
+max_lines_per_pr = 300
+prefer_single_concern_prs = true
+
+[fyi]
+repo_is_primarily_spec_and_docs = true
+source_of_truth = nbs/index.qmd
+rendered_site = https://llmstxt.org/


### PR DESCRIPTION
Hi Jeremy 👋

agents.txt v1.0 shipped today, and its stated lineage is `robots.txt → sitemap.xml → llms.txt → agents.txt`. llms.txt is explicitly cited as the immediate parent — the thing that made it normal to have a plain-text file at a known path aimed at non-human readers. So this PR is a courtesy cross-link, not an ask.

### What this adds

- One new file: `/agents.txt` at the repo root, in the v1.0 INI format.

That's it. It's tuned for what this repo actually is — a spec and docs project with a small Python helper — rather than copy-pasted boilerplate. Allowed actions are read/PR/issue-comment; prohibited actions cover the obvious (no merging, no PyPI pushes, no history rewrites); spec text and the `nbs/` source require human approval; entry points point at `nbs/index.qmd` as source of truth and `llmstxt.org` as the rendered site.

### What this doesn't do

- No CI changes
- No changes to README, the spec, or any existing file
- No new dependencies
- No coupling to anything upstream — agents.txt is a separate standard with its own repo; this PR doesn't ask llms-txt to endorse it, just to host a file that points agents at the right entry points for *this* project

### Why bother

Agents are already crawling spec repos and occasionally opening low-signal PRs. Having an `agents.txt` at the root gives them an unambiguous "here's what's allowed, here's what needs a human" surface — same idea as llms.txt, one layer up the stack.

Full v1.0 spec for reference: https://github.com/barneywohl/agentpress/blob/main/docs/AGENTSTXT_SPEC.md

Totally fine to close this if it's not a fit — no hard feelings, and thanks for llms.txt either way.