### PR TITLE
Add Sourcey to Integrations

### DIFF
--- a/nbs/index.qmd
+++ b/nbs/index.qmd
@@ -127,7 +127,7 @@ Various tools and plugins are available to help integrate the llms.txt specifica
 - [JavaScript Implementation](./llmstxt-js.html) - Sample JavaScript implementation
 - [`vitepress-plugin-llms`](https://github.com/okineadev/vitepress-plugin-llms) - VitePress plugin that automatically generates LLM-friendly documentation for the website following the llms.txt specification
 - [`docusaurus-plugin-llms`](https://github.com/rachfop/docusaurus-plugin-llms) - Docusaurus plugin for generating LLM-friendly documentation following the llmtxt.org standard
-- [Sourcey](https://github.com/sourcey/sourcey) - Multi-source documentation generator (OpenAPI, MCP, Doxygen, godoc, Markdown) that emits `llms.txt` and `llms-full.txt` as first-class build artefacts alongside the static HTML output
+- [Sourcey](https://sourcey.com) - Multi-source documentation generator (OpenAPI, MCP, Doxygen, godoc, Markdown) that emits `llms.txt` and `llms-full.txt` as first-class build artefacts alongside the static HTML output
 - [Drupal LLM Support](https://www.drupal.org/project/llm_support) - A Drupal Recipe providing full support for the llms.txt proposal on any Drupal 10.3+ site
 - [`llms-txt-php`](https://github.com/raphaelstolt/llms-txt-php) - A library for writing and reading llms.txt Markdown files
 - [`VS Code PagePilot Extension`](https://dmux.github.io/pagepilot) - PagePilot is a VS Code Chat participant that automatically loads external context (documentation, APIs, README files) to provide enhanced responses.

--- a/nbs/index.qmd
+++ b/nbs/index.qmd
@@ -127,6 +127,7 @@ Various tools and plugins are available to help integrate the llms.txt specifica
 - [JavaScript Implementation](./llmstxt-js.html) - Sample JavaScript implementation
 - [`vitepress-plugin-llms`](https://github.com/okineadev/vitepress-plugin-llms) - VitePress plugin that automatically generates LLM-friendly documentation for the website following the llms.txt specification
 - [`docusaurus-plugin-llms`](https://github.com/rachfop/docusaurus-plugin-llms) - Docusaurus plugin for generating LLM-friendly documentation following the llmtxt.org standard
+- [Sourcey](https://github.com/sourcey/sourcey) - Multi-source documentation generator (OpenAPI, MCP, Doxygen, godoc, Markdown) that emits `llms.txt` and `llms-full.txt` as first-class build artefacts alongside the static HTML output
 - [Drupal LLM Support](https://www.drupal.org/project/llm_support) - A Drupal Recipe providing full support for the llms.txt proposal on any Drupal 10.3+ site
 - [`llms-txt-php`](https://github.com/raphaelstolt/llms-txt-php) - A library for writing and reading llms.txt Markdown files
 - [`VS Code PagePilot Extension`](https://dmux.github.io/pagepilot) - PagePilot is a VS Code Chat participant that automatically loads external context (documentation, APIs, README files) to provide enhanced responses.


### PR DESCRIPTION
Sourcey (https://sourcey.com) is a multi-source documentation generator that consumes OpenAPI, MCP server manifests, Doxygen XML, godoc, and Markdown sources and emits a single static HTML site. It ships llms.txt and llms-full.txt as first-class build artefacts alongside the HTML output, so the same source produces docs for humans and structured context for AI agents in one build.

Fits the Integrations section alongside the existing VitePress, Docusaurus, and Drupal entries.

- Project: https://sourcey.com
- Live llms.txt: https://sourcey.com/docs/llms.txt
- Source: https://github.com/sourcey/sourcey
- License: AGPL-3.0

Edit lands in nbs/index.qmd; README.md is the symlink-rendered output.