### PR TITLE
Add llmtxt.info (verified directory) and llms-txt-toolkit to Directories/Integrations

### DIFF
--- a/nbs/index.qmd
+++ b/nbs/index.qmd
@@ -119,6 +119,7 @@ Here are a few directories that list the `llms.txt` files available on the web:
 
 - [llmstxt.site](https://llmstxt.site/)
 - [directory.llmstxt.cloud](https://directory.llmstxt.cloud/)
+- [llmtxt.info directory](https://llmtxt.info/examples/) - directory of llms.txt files in production, re-verified weekly by an automated checker, with measured adoption statistics
 
 ## Integrations
 
@@ -129,6 +130,7 @@ Various tools and plugins are available to help integrate the llms.txt specifica
 - [`vitepress-plugin-llms`](https://github.com/okineadev/vitepress-plugin-llms) - VitePress plugin that automatically generates LLM-friendly documentation for the website following the llms.txt specification
 - [`docusaurus-plugin-llms`](https://github.com/rachfop/docusaurus-plugin-llms) - Docusaurus plugin for generating LLM-friendly documentation following the llmtxt.org standard
 - [Drupal LLM Support](https://www.drupal.org/project/llm_support) - A Drupal Recipe providing full support for the llms.txt proposal on any Drupal 10.3+ site
+- [`llms-txt-toolkit`](https://github.com/abovefear/llms-txt-toolkit) - TypeScript validator with structured diagnostics, sitemap-based generator, and adoption tracker; free hosted versions at [llmtxt.info](https://llmtxt.info/validator/)
 - [`llms-txt-php`](https://github.com/raphaelstolt/llms-txt-php) - A library for writing and reading llms.txt Markdown files
 - [`VS Code PagePilot Extension`](https://dmux.github.io/pagepilot) - PagePilot is a VS Code Chat participant that automatically loads external context (documentation, APIs, README files) to provide enhanced responses.
 


### PR DESCRIPTION
Two additions:

**Directories**: [llmtxt.info/examples/](https://llmtxt.info/examples/) lists llms.txt files in production and re-verifies every entry weekly with an automated checker (entries that disappear are removed). It also publishes measured adoption statistics over a fixed panel of 219 hosts, with the raw data as JSON ([methodology](https://llmtxt.info/llms-txt-adoption/)).

**Integrations**: [llms-txt-toolkit](https://github.com/abovefear/llms-txt-toolkit) (MIT) is the TypeScript validator (structured diagnostics with stable rule codes), sitemap-based generator, and adoption checker behind the site. Free hosted versions: [validator](https://llmtxt.info/validator/), [generator](https://llmtxt.info/generator/).

Format follows the existing entries; happy to adjust wording or trim to one entry if preferred.