### PR TITLE
Add turva.dev llms.txt validator to Integrations

### DIFF
--- a/nbs/index.qmd
+++ b/nbs/index.qmd
@@ -131,6 +131,7 @@ Various tools and plugins are available to help integrate the llms.txt specifica
 - [Drupal LLM Support](https://www.drupal.org/project/llm_support) - A Drupal Recipe providing full support for the llms.txt proposal on any Drupal 10.3+ site
 - [`llms-txt-php`](https://github.com/raphaelstolt/llms-txt-php) - A library for writing and reading llms.txt Markdown files
 - [`VS Code PagePilot Extension`](https://dmux.github.io/pagepilot) - PagePilot is a VS Code Chat participant that automatically loads external context (documentation, APIs, README files) to provide enhanced responses.
+- [turva.dev llms.txt validator](https://turva.dev/llms-txt-validator) - Free web-based validator that checks a site's llms.txt against the proposed format, reporting pass, warn or fail per check, with JSON output for agents
 
 ## Next steps
 


### PR DESCRIPTION
Adds a free web-based llms.txt validator to the Integrations list: https://turva.dev/llms-txt-validator

It checks a site's llms.txt against the format described on this page (H1, blockquote summary, H2 file-list sections), reports pass, warn or fail per check, and returns JSON when requested with an Accept: application/json header. No signup.

Edited nbs/index.qmd only since README.md appears to be generated from it; happy to mirror the line there too if you prefer.