### PR TITLE
Add agent-readiness-auditor to Integrations

### DIFF
--- a/nbs/index.qmd
+++ b/nbs/index.qmd
@@ -131,6 +131,7 @@ Various tools and plugins are available to help integrate the llms.txt specifica
 - [Drupal LLM Support](https://www.drupal.org/project/llm_support) - A Drupal Recipe providing full support for the llms.txt proposal on any Drupal 10.3+ site
 - [`llms-txt-php`](https://github.com/raphaelstolt/llms-txt-php) - A library for writing and reading llms.txt Markdown files
 - [`VS Code PagePilot Extension`](https://dmux.github.io/pagepilot) - PagePilot is a VS Code Chat participant that automatically loads external context (documentation, APIs, README files) to provide enhanced responses.
+- [`agent-readiness-auditor`](https://github.com/asish-singh/agent-readiness-auditor) - CLI that scores any website's readiness for AI agents across nine checks, including llms.txt presence; runs with `npx agent-readiness-auditor <site>` and also ships as an MCP server
 
 ## Next steps
 


### PR DESCRIPTION
Adds an open source auditing CLI to the Integrations list. It scans a website and scores its readiness for AI agents across nine checks, hidden prompt injection text, llms.txt presence, robots.txt stance on AI crawlers, structured data (JSON-LD), sitemap presence, accountability and contact links, answer shaped content, index blocking via meta robots, and advertised agent endpoints (MCP). It is published on npm under an MIT license with no signup required, ships as an MCP server so assistants can run the audit directly, and powers [The Agentic Web Index](https://github.com/asish-singh/agentic-web-index), a quarterly audit of 200 prominent sites whose adoption data I shared in #93.

Edited nbs/index.qmd only, since README.md appears to be generated from it. Happy to mirror the line there too if preferred.