### PR TITLE
Add turva-llms-txt-validator to Integrations

### DIFF
--- a/nbs/index.qmd
+++ b/nbs/index.qmd
@@ -131,6 +131,7 @@ Various tools and plugins are available to help integrate the llms.txt specifica
 - [Drupal LLM Support](https://www.drupal.org/project/llm_support) - A Drupal Recipe providing full support for the llms.txt proposal on any Drupal 10.3+ site
 - [`llms-txt-php`](https://github.com/raphaelstolt/llms-txt-php) - A library for writing and reading llms.txt Markdown files
 - [`VS Code PagePilot Extension`](https://dmux.github.io/pagepilot) - PagePilot is a VS Code Chat participant that automatically loads external context (documentation, APIs, README files) to provide enhanced responses.
+- [`turva-llms-txt-validator`](https://github.com/erekola/llms-txt-validator) - CLI and Node module that validates a site's /llms.txt structure against the specification, reporting each check as pass, warn or fail, with JSON output for CI
 
 ## Next steps
 


### PR DESCRIPTION
Adds turva-llms-txt-validator to the Integrations list: an MIT-licensed npm package with a CLI (llms-txt-validate) and a Node API that validates a site's /llms.txt against this spec. Seven structure checks (file present at /llms.txt, plain text response, single H1 title, blockquote summary, H2 sections, followable markdown links, size), each reported as pass, warn or fail, with --json output and exit codes for CI.

npm: https://www.npmjs.com/package/turva-llms-txt-validator
The same checks run as a free hosted validator at https://turva.dev/llms-txt-validator.