### PR TITLE
Add llms-txt-lint to Integrations

### DIFF
--- a/nbs/index.qmd
+++ b/nbs/index.qmd
@@ -131,6 +131,7 @@ Various tools and plugins are available to help integrate the llms.txt specifica
 - [Drupal LLM Support](https://www.drupal.org/project/llm_support) - A Drupal Recipe providing full support for the llms.txt proposal on any Drupal 10.3+ site
 - [`llms-txt-php`](https://github.com/raphaelstolt/llms-txt-php) - A library for writing and reading llms.txt Markdown files
 - [`VS Code PagePilot Extension`](https://dmux.github.io/pagepilot) - PagePilot is a VS Code Chat participant that automatically loads external context (documentation, APIs, README files) to provide enhanced responses.
+- [`llms-txt-lint`](https://github.com/abyworkings-coder/llms-txt-lint) - Zero-dependency CLI and GitHub Action that validates llms.txt files against the spec (section order, required H1/blockquote, dead links) and can output JSON for CI pipelines
 
 ## Next steps
 


### PR DESCRIPTION
## Summary
- Adds `llms-txt-lint` to the Integrations list — a zero-dependency Node.js CLI and companion GitHub Action that validates an `llms.txt` file against this spec (correct section order, required H1 title + blockquote summary, dead link detection in listed resources).
- Includes a `--json` output mode for piping results into CI dashboards or PR bots.
- Repo: https://github.com/abyworkings-coder/llms-txt-lint

## Test plan
- [x] Verified the tool runs against both a spec-compliant fixture (exits 0) and a broken fixture (exits 1, reports errors/warnings) before submitting this entry
- [x] Single-line addition, consistent with the format of the other Integrations entries