### PR TITLE
Change logo formatting in llms.txt proposal

### DIFF
--- a/nbs/index.qmd
+++ b/nbs/index.qmd
@@ -14,7 +14,7 @@ While websites serve both human readers and LLMs, the latter benefit from more c
 
 ## Proposal
 
-![llms.txt logo](logo.png){.lightbox width=150px .floatr}
+<img src="logo.png" alt="llms.txt logo" width="150" align="right">
 
 We propose adding a `/llms.txt` markdown file to websites to provide LLM-friendly content. This file offers brief background information, guidance, and links to detailed markdown files.
 


### PR DESCRIPTION
Updated the README to use GitHub compatible image syntax by replacing image attribute syntax with standard HTML.

## Preview of README before the change (this is an image):


<img width="447" height="196" alt="Screenshot From 2026-08-05 15-34-40" src="https://github.com/user-attachments/assets/e7e563a7-068e-4d81-9e0d-85ac795c6a89" />
