### PR TITLE
Update CLI flags for fastcore.script hyphenation

### DIFF
--- a/nbs/nbdev.qmd
+++ b/nbs/nbdev.qmd
@@ -140,7 +140,7 @@ dev_requirements = pysym2md
 project:
   type: website
   pre-render:
-    - pysym2md --output_file apilist.txt nbdev
+    - pysym2md --output-file apilist.txt nbdev
   resources:
     - "*.txt"
 ```


### PR DESCRIPTION
Update affected documentation, automation, tests, and saved notebook output to use the hyphenated CLI flags now generated from underscored `fastcore.script` parameters.

This keeps examples and build/test commands compatible with current fastcore.