### PR TITLE
Add laravel-llms-txt to Integrations

### DIFF
--- a/nbs/index.qmd
+++ b/nbs/index.qmd
@@ -147,6 +147,7 @@ And various libraries and plugins are available to integrate the llms.txt specif
 - [`docusaurus-plugin-llms`](https://github.com/rachfop/docusaurus-plugin-llms) - Docusaurus plugin for generating LLM-friendly documentation following the llmtxt.org standard
 - [Drupal LLM Support](https://www.drupal.org/project/llm_support) - A Drupal Recipe providing full support for the llms.txt proposal on any Drupal 10.3+ site
 - [`llms-txt-php`](https://github.com/raphaelstolt/llms-txt-php) - A library for writing and reading llms.txt Markdown files
+- [`laravel-llms-txt`](https://github.com/schaefersoft/laravel-llms-txt) - Automatically generate llms.txt and llms-full.txt for Laravel applications
 - [`VS Code PagePilot Extension`](https://dmux.github.io/pagepilot) - PagePilot is a VS Code Chat participant that automatically loads external context (documentation, APIs, README files) to provide enhanced responses.
 - [`server-llm-txt`](https://github.com/mcp-get/community-servers/tree/main/src/server-llm-txt) - MCP server that lets agents fetch and search llms.txt files
 


### PR DESCRIPTION
Add the `laravel-llms-txt` library to the integrations section.