### PR TITLE
Handle llms.txt sections without links

### DIFF
--- a/llms_txt/core.py
+++ b/llms_txt/core.py
@@ -40,11 +40,11 @@ def parse_link(txt):
     desc = named_re('desc', r'.*')
     desc_pat = opt_re(fr":\s*{desc}")
     pat = fr'-\s*\[{title}\]\({url}\){desc_pat}'
-    return re.search(pat, txt).groupdict()
+    return search(pat, txt)
 
 # %% ../nbs/01_core.ipynb #23dee0c8
 def _parse_links(links):
-    return [parse_link(l) for l in re.split(r'\n+', links.strip()) if l.strip()]
+    return [link for l in re.split(r'\n+', links.strip()) if (link := parse_link(l))]
 
 # %% ../nbs/01_core.ipynb #60a080c3
 def _parse_llms(txt):
@@ -59,9 +59,8 @@ def parse_llms_file(txt):
     start,sects = _parse_llms(txt)
     title = named_re('title', r'.+?$')
     summ = named_re('summary', '.+?$')
-    summ_pat = opt_re(fr"^>\s*{summ}$")
     info = named_re('info', '.*')
-    pat = fr'^#\s*{title}\n+{summ_pat}\n+{info}'
+    pat = fr'^#\s*{title}(?:\n+^>\s*{summ}$)?(?:\n+{info})?$'
     d = search(pat, start, (re.MULTILINE|re.DOTALL))
     d['sections'] = sects
     return dict2obj(d)

--- a/nbs/01_core.ipynb
+++ b/nbs/01_core.ipynb
@@ -271,7 +271,7 @@
     "    desc = named_re('desc', r'.*')\n",
     "    desc_pat = opt_re(fr\":\\s*{desc}\")\n",
     "    pat = fr'-\\s*\\[{title}\\]\\({url}\\){desc_pat}'\n",
-    "    return re.search(pat, txt).groupdict()"
+    "    return search(pat, txt)"
    ]
   },
   {
@@ -448,7 +448,7 @@
    "outputs": [],
    "source": [
     "def _parse_links(links):\n",
-    "    return [parse_link(l) for l in re.split(r'\\n+', links.strip()) if l.strip()]"
+    "    return [link for l in re.split(r'\\n+', links.strip()) if (link := parse_link(l))]"
    ]
   },
   {
@@ -546,7 +546,7 @@
     }
    ],
    "source": [
-    "pat = fr'^#\\s*{title}\\n+{summ_pat}\\n+{info}'\n",
+    "pat = fr'^#\\s*{title}(?:\\n+^>\\s*{summ}$)?(?:\\n+{info})?$'\n",
     "search(pat, start, (re.MULTILINE|re.DOTALL))"
    ]
   },
@@ -566,12 +566,35 @@
     "    start,sects = _parse_llms(txt)\n",
     "    title = named_re('title', r'.+?$')\n",
     "    summ = named_re('summary', '.+?$')\n",
-    "    summ_pat = opt_re(fr\"^>\\s*{summ}$\")\n",
     "    info = named_re('info', '.*')\n",
-    "    pat = fr'^#\\s*{title}\\n+{summ_pat}\\n+{info}'\n",
+    "    pat = fr'^#\\s*{title}(?:\\n+^>\\s*{summ}$)?(?:\\n+{info})?$'\n",
     "    d = search(pat, start, (re.MULTILINE|re.DOTALL))\n",
     "    d['sections'] = sects\n",
     "    return dict2obj(d)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "83c19065",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "no_links_section = '''# No Links Title\n",
+    "\n",
+    "## Description\n",
+    "\n",
+    "> No description\n",
+    "\n",
+    "Some details without links\n",
+    "'''\n",
+    "parsed = parse_llms_file(no_links_section)\n",
+    "assert parsed == {\n",
+    "    'title': 'No Links Title',\n",
+    "    'summary': None,\n",
+    "    'info': None,\n",
+    "    'sections': {'Description': []},\n",
+    "}"
    ]
   },
   {


### PR DESCRIPTION
## Summary

- skip plain-text lines when parsing link sections
- accept a title-only preamble before the first section
- add a regression test for the document reported in #16

## Validation

- `nbdev-clean`
- `nbdev-export`
- `PYTHONUTF8=1 nbdev-test --flags ""`
- `python tests/test-parse.py`

Fixes #16